### PR TITLE
add support for divclass syntax

### DIFF
--- a/src/cdoFlavoredParser.js
+++ b/src/cdoFlavoredParser.js
@@ -7,12 +7,18 @@ const renderRedactions = require('./plugins/renderRedactions');
 const restoreRedactions = require('./plugins/restoreRedactions');
 const restorationRegistration = require('./plugins/restorationRegistration');
 
+const divclass = require('./plugins/divclass');
 const redactedLink = require('./plugins/redactedLink');
 const tiplink = require('./plugins/tiplink');
 
 module.exports = class CdoFlavoredParser {
   static getPlugins = function() {
-    return [restorationRegistration, redactedLink, tiplink];
+    return [
+      restorationRegistration,
+      divclass,
+      redactedLink,
+      tiplink
+    ];
   };
 
   static getParser = function() {

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -106,7 +106,7 @@ function tokenizeDivclass(eat, value, silent) {
   const className = startMatch[1];
 
   const divclassClose = `\n\n[/${className}]`;
-  const endIndex = value.slice(startIndex).indexOf(divclassClose);
+  const endIndex = value.indexOf(divclassClose, startIndex);
 
   if (endIndex === -1) {
     return;
@@ -116,7 +116,7 @@ function tokenizeDivclass(eat, value, silent) {
     return true;
   }
 
-  const subvalue = value.slice(startIndex, startIndex + endIndex);
+  const subvalue = value.slice(startIndex, endIndex);
   const contents = this.tokenizeBlock(subvalue, eat.now());
 
   if (redact) {

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -1,7 +1,4 @@
 /**
- * @file divclass
- * @example
- *
  * ### Divclass
  * 
  * We support the ability to wrap content in divs with a declared class

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -1,0 +1,176 @@
+/**
+ * @file divclass
+ * @example
+ *
+ * ### Divclass
+ * 
+ * We support the ability to wrap content in divs with a declared class
+ * attribute. Any kind of block content is supported; to wrap the content, simply
+ * precede it with a block entirely consisting of the class name wrapped in square
+ * bracked and succeed it with a block entirely consisting of the class name
+ * preceeded by a forward slash and wrapped in square brackets.
+ * 
+ * [col-33]
+ * 
+ * This is some simple content that will be wrapped in a div with the class "col-33"
+ * 
+ * [/col-33]
+ * 
+ * [col-33]
+ * 
+ * - This is a ul, which will also be wrapped in a div with the class "col-33".
+ * - Note that because this is dealing with classes and not ids, duplicate class
+ * - names are just fine.
+ * 
+ * [/col-33]
+ * 
+ * [outer]
+ * 
+ * [inner]
+ * 
+ * Nesting of classes is also supported.
+ * 
+ * [/inner]
+ * 
+ * [/outer]
+ * 
+ * [unsupported]
+ * 
+ * Some things that are NOT supported:
+ * 
+ * - inline divclasses like [example]this[/example]
+ * - generic endings like [example]\n\ncontent\n\n[/]
+ * - indentation like [example]\n\n    content\n\n[/example]
+ *   - in this case, 'content' would be treated as a code block
+ * 
+ * [/unsupported]
+ *
+ * Note that you can also add an empty div without content like so:
+ *
+ * [empty]
+ *
+ *
+ *
+ * [/empty]
+ *
+ * ### Redacting
+ *
+ * Divclasses will be redacted to just [] and [/]:
+ *
+ * []
+ * 
+ * This is some simple content that will be wrapped in a div with the class "col-33"
+ * 
+ * [/]
+ */
+
+const DIVCLASS_OPEN_RE = /^\[([\w-]+)\]\n\n/;
+
+let redact;
+
+module.exports = function divclass() {
+
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.blockTokenizers;
+  const methods = Parser.prototype.blockMethods;
+  const restorationMethods = Parser.prototype.restorationMethods;
+
+  restorationMethods.divclass = function (add, node) {
+    console.log(node);
+  }
+
+  redact = Parser.prototype.options.redact;
+
+  tokenizers.divclass = tokenizeDivclass;
+
+  /* Run it just before `paragraph`. */
+  methods.splice(methods.indexOf('paragraph'), 0, 'divclass');
+}
+
+//module.exports.out = function out() {
+//  var Compiler = this.Compiler;
+//  var visitors = Compiler.prototype.visitors;
+//  //console.log(Compiler);
+//  //console.log(Compiler.prototype);
+//  //console.log(visitors);
+
+//  var original = visitors.linkReference;
+//  visitors.linkReference = function heading(node) {
+//    const definitions = this.tree.children.filter(child => child.type === "definition");
+
+//    const mydef = definitions.find(def => def.identifier.toLowerCase() === node.identifier.toLowerCase());
+
+//    if (mydef && mydef.meta) {
+//      switch (mydef.meta) {
+//        case 'link':
+//        case 'image':
+//          break
+//        case 'divclass':
+//          console.log(mydef, node);
+//          const val = node.children.length ? node.children[0].value : "";
+//          return "[" + val + mydef.url + "]";
+//          break
+//      }
+//    }
+
+//    return original.apply(this, arguments);
+//  }
+//}
+
+tokenizeDivclass.notInLink = true;
+
+function tokenizeDivclass(eat, value, silent) {
+  const startMatch = DIVCLASS_OPEN_RE.exec(value)
+
+  if (!startMatch) {
+    return;
+  }
+
+  const startIndex = startMatch[0].length;
+  const className = startMatch[1];
+  const DIVCLASS_CLOSE_RE = RegExp(`\n\n\\[/${className}\\]`);
+
+  const endMatch = DIVCLASS_CLOSE_RE.exec(value.slice(startIndex))
+
+  if (!endMatch) {
+    return;
+  }
+
+  if (silent) {
+    return true;
+  }
+
+  const endIndex = startIndex + endMatch.index;
+  const subvalue = value.slice(startIndex, endIndex);
+  const contents = this.tokenizeBlock(subvalue, eat.now());
+
+  if (redact) {
+    const open = eat(startMatch[0])({
+      type: 'redaction',
+      redactionType: 'divclass',
+      className: className,
+    });
+
+    const add = eat(subvalue);
+    const content = contents.map((content) => add(content));
+
+    const close = eat(endMatch[0])({
+      type: 'redaction',
+      redactionType: 'divclass',
+      className: className,
+      closing: true
+    });
+
+    return [open, ...content, close]
+  }
+
+  return eat(startMatch[0] + subvalue + endMatch[0])({
+    type: 'div',
+    children: contents,
+    data: {
+      hProperties: {
+        className: className
+      },
+    }
+  });
+}

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -52,13 +52,14 @@
  *
  * ### Redacting
  *
- * Divclasses will be redacted to just [] and [/]:
+ * Divclasses will be redacted to just [][0] and [/][0], where "0" is the
+ * zero-based index of the divclass in the set of all redactions in the content:
  *
- * []
+ * [][0]
  * 
  * This is some simple content that will be wrapped in a div with the class "col-33"
  * 
- * [/]
+ * [/][0]
  */
 
 const DIVCLASS_OPEN_RE = /^\[([\w-]+)\]\n\n/;

--- a/src/plugins/renderRedactions.js
+++ b/src/plugins/renderRedactions.js
@@ -48,7 +48,15 @@ module.exports = function renderRedactions() {
       }
       exit();
 
-      return `[${value}][${count++}]`;
+      let prefix = "";
+      let index = "";
+      if (node.closing) {
+        prefix = "/";
+      } else {
+        index = count++;
+      }
+
+      return `[${prefix}${value}][${index}]`;
     }
   }
 }

--- a/src/plugins/restoreRedactions.js
+++ b/src/plugins/restoreRedactions.js
@@ -52,14 +52,12 @@ module.exports = function restoreRedactions(sourceTree) {
     }
 
     const Parser = this.Parser;
-    const tokenizers = Parser.prototype.inlineTokenizers;
-    const methods = Parser.prototype.inlineMethods;
-
 
     // A redacted value looks like [some text][0], where "some text" is
     // something that can be translated and "0" is the index of the redacted
     // value.
     const REDACTION_RE = /^\[([^\]]*)\]\[(\d+)\]/;
+    const REDACTION_CLOSE_RE = /^\[\/([^\]]*)\]\[\]/;
 
     const tokenizeRedaction = function (eat, value, silent) {
       const match = REDACTION_RE.exec(value);
@@ -95,9 +93,10 @@ module.exports = function restoreRedactions(sourceTree) {
     }
 
     /* Add an inline tokenizer (defined in the following example). */
-    tokenizers.redaction = tokenizeRedaction;
+    Parser.prototype.inlineTokenizers.redaction = tokenizeRedaction;
 
     /* Run before default reference. */
-    methods.splice(methods.indexOf('reference'), 0, 'redaction');
+    const inlineMethods = Parser.prototype.inlineMethods;
+    inlineMethods.splice(inlineMethods.indexOf('reference'), 0, 'redaction');
   }
 }

--- a/src/plugins/restoreRedactions.js
+++ b/src/plugins/restoreRedactions.js
@@ -124,7 +124,7 @@ module.exports = function restoreRedactions(sourceTree) {
     //
     //     [some text][0]
     //
-    //     some other markdown content entirely independent of the redaction
+    //     some other markdown content contained within the redaction
     //
     //     [/][0]
     //

--- a/src/plugins/restoreRedactions.js
+++ b/src/plugins/restoreRedactions.js
@@ -30,12 +30,30 @@
  * @requires restorationRegistration
  */
 module.exports = function restoreRedactions(sourceTree) {
-
-  // first, walk the source tree and find all redacted nodes.
+  // First, walk the source tree and find all redacted nodes.
+  // Block nodes should come in open, close pairs that share an index; entries
+  // in the redactions array should therefore either be an object representing a
+  // single node or an object with three values:
+  // - block = true - indicating that this is a block object
+  // - open - node representing the opening block
+  // - close - node representing the closing block
   const redactions = [];
+  const openBlockIndexes = [];
   function getRedactedValues(node) {
     if (node.type === "redaction") {
-      redactions.push(node);
+      if (node.block) {
+        if (node.closing) {
+          redactions[openBlockIndexes.shift()].close = node;
+        } else {
+          openBlockIndexes.unshift(redactions.length);
+          redactions.push({
+            block: true,
+            open: node
+          });
+        }
+      } else {
+        redactions.push(node);
+      }
     }
 
     if (node.children && node.children.length) {
@@ -53,28 +71,27 @@ module.exports = function restoreRedactions(sourceTree) {
 
     const Parser = this.Parser;
 
-    // A redacted value looks like [some text][0], where "some text" is
+    // Add an inline tokenizer
+    //
+    // A redacted inline value looks like [some text][0], where "some text" is
     // something that can be translated and "0" is the index of the redacted
     // value.
-    const REDACTION_RE = /^\[([^\]]*)\]\[(\d+)\]/;
-    const REDACTION_CLOSE_RE = /^\[\/([^\]]*)\]\[\]/;
-
-    const tokenizeRedaction = function (eat, value, silent) {
-      const match = REDACTION_RE.exec(value);
+    const INLINE_REDACTION_RE = /^\[([^\]]*)\]\[(\d+)\]/;
+    const tokenizeInlineRedaction = function (eat, value, silent) {
+      const match = INLINE_REDACTION_RE.exec(value);
       if (!match) {
         return;
       }
 
-      if (silent) {
-        return true;
-      }
+      // the translated data inside the first set of brackets
+      const content = match[1];
 
-      const content = match[1]; // the translated data inside the first set of brackets
-      const index = parseInt(match[2], 10); // the sequential index inside the second set of brackets
-      const redactedData = redactions[index];
+      // the sequential index inside the second set of brackets
+      const index = parseInt(match[2], 10);
 
       // TODO once we decide on how we want to handle errors, this is where the
       // error handler should probably go
+      const redactedData = redactions[index];
       if (!redactedData) {
         return;
       }
@@ -84,19 +101,99 @@ module.exports = function restoreRedactions(sourceTree) {
         return
       }
 
+      if (silent) {
+        return true;
+      }
+
       const add = eat(match[0]);
       return restorationMethod(add, redactedData, content);
     }
 
-    tokenizeRedaction.locator = function (value) {
-      return value.search(REDACTION_RE);
+    tokenizeInlineRedaction.locator = function (value) {
+      return value.search(INLINE_REDACTION_RE);
     }
 
-    /* Add an inline tokenizer (defined in the following example). */
-    Parser.prototype.inlineTokenizers.redaction = tokenizeRedaction;
-
-    /* Run before default reference. */
+    Parser.prototype.inlineTokenizers.redaction = tokenizeInlineRedaction;
     const inlineMethods = Parser.prototype.inlineMethods;
     inlineMethods.splice(inlineMethods.indexOf('reference'), 0, 'redaction');
+
+    // Add a block tokenizer
+    //
+    // A redacted block will actually be two "blocks" representing the open and
+    // close of a redacted block. Together, they will look like:
+    //
+    //     [some text][0]
+    //
+    //     some other markdown content entirely independent of the redaction
+    //
+    //     [/][0]
+    //
+    // Where "some text" is something that can be translated  and "0" is the
+    // index of the redacted value.
+    const tokenizeBlockRedaction = function (eat, value, silent) {
+      const BLOCK_REDACTION_RE = /^\[([^\]]*)\]\[(\d+)\]\n\n/;
+      const startMatch = BLOCK_REDACTION_RE.exec(value)
+
+      // if we don't find an open block, return immediately
+      if (!startMatch) {
+        return;
+      }
+
+      // the entire string representing the "open" block of the redaction
+      const blockOpen = startMatch[0];
+
+      // the index within `value` at which the inner content of the redacted block begins
+      // (ie the index at which the "open" block ends)
+      const startIndex = startMatch[0].length;
+
+      // the translated data inside the first set of brackets
+      const content = startMatch[1];
+
+      // the sequential index inside the second set of brackets
+      const index = parseInt(startMatch[2], 10);
+
+      // if we don't have a redaction matching this index, return immediately
+      // TODO once we decide on how we want to handle errors, this is where the
+      // error handler should probably go
+      const redactedData = redactions[index];
+      if (!(redactedData && redactedData.block)) {
+        return;
+      }
+
+      // the entire string representing the "close" block of the redaction
+      const blockClose = `\n\n[/][${index}]`;
+
+      // the index within `value` at which the inner content of the redacted block ends
+      // (ie the index at which the "close" block begins)
+      const endIndex = value.slice(startIndex).indexOf(blockClose);
+
+      // if we didn't find a close block, return immediately
+      if (endIndex === -1) {
+        return;
+      }
+
+      const restorationMethod = Parser.prototype.restorationMethods[redactedData.open.redactionType];
+      if (!restorationMethod) {
+        return
+      }
+
+      // if we get to here, then we have found a valid block! Return true if in
+      // silent mode to indicate a passing test
+      if (silent) {
+        return true;
+      }
+
+      // if in normal (ie non-silent) mode, consume the token and produce a
+      // render
+      const subvalue = value.slice(startIndex, startIndex + endIndex);
+      const children = this.tokenizeBlock(subvalue, eat.now());
+      const add = eat(blockOpen + subvalue + blockClose);
+      return restorationMethod(add, redactedData, content, children);
+    }
+
+    /* Run before default reference. */
+    Parser.prototype.blockTokenizers.redaction = tokenizeBlockRedaction;
+    const blockMethods = Parser.prototype.blockMethods;
+    blockMethods.splice(blockMethods.indexOf('paragraph'), 0, 'redaction');
   }
 }

--- a/src/plugins/restoreRedactions.js
+++ b/src/plugins/restoreRedactions.js
@@ -165,7 +165,7 @@ module.exports = function restoreRedactions(sourceTree) {
 
       // the index within `value` at which the inner content of the redacted block ends
       // (ie the index at which the "close" block begins)
-      const endIndex = value.slice(startIndex).indexOf(blockClose);
+      const endIndex = value.indexOf(blockClose, startIndex);
 
       // if we didn't find a close block, return immediately
       if (endIndex === -1) {
@@ -185,7 +185,7 @@ module.exports = function restoreRedactions(sourceTree) {
 
       // if in normal (ie non-silent) mode, consume the token and produce a
       // render
-      const subvalue = value.slice(startIndex, startIndex + endIndex);
+      const subvalue = value.slice(startIndex, endIndex);
       const children = this.tokenizeBlock(subvalue, eat.now());
       const add = eat(blockOpen + subvalue + blockClose);
       return restorationMethod(add, redactedData, content, children);

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -49,7 +49,7 @@ describe('Standard Markdown', () => {
     expect(output).toEqual("<p>C'est du texte avec <a href=\"http://first.com\">un lien</a> et pas d'une image.</p>\n<p>Et aussi un deuxième paragraphe avec <a href=\"http://third.com\">un autre lien</a></p>\n");
   });
 
-  it('will handle extra/unwanted redactions by just ignoring them', () => {
+  it('will handle extra/unwanted redactions by defaulting them to empty links', () => {
     const source = "This is some text with [a link](http://example.com/)";
     const redacted = "C'est du texte avec [un lien][0] et [une image][1]";
     const output = parser.sourceAndRedactedToHtml(source, redacted);

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -50,6 +50,12 @@ describe('divclass', () => {
       const output = parser.sourceToHtml(input);
       expect(output).toEqual("<div class=\"example\"><pre><code>simple content\n</code></pre></div>\n");
     });
+
+    it('can render complex content inside a divclass', () => {
+      const input = "[complex-example]\n\n-   an ordered list\n-   with **inline** _formatting_, too\n\n[/complex-example]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"complex-example\"><ul>\n<li>an ordered list</li>\n<li>with <strong>inline</strong> <em>formatting</em>, too</li>\n</ul></div>\n");
+    });
   });
 
   describe('redact', () => {
@@ -77,26 +83,39 @@ describe('divclass', () => {
       expect(output).toEqual("[][0]\n\nfirst\n\n[/][0]\n\n[][1]\n\nsecond\n\n[/][1]\n");
     });
 
-    it('can nest divclasses', () => {
+    it('can redact nested divclasses', () => {
       const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
       const output = parser.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\n[][1]\n\nnested\n\n[/][1]\n\n[/][0]\n");
     });
+
+    it('can redact inline content inside a divclass', () => {
+      const input = "[complex-example]\n\n-   an ordered list\n-   with [other redacted content](http://example.com)\n\n[/complex-example]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n\n-   an ordered list\n-   with [other redacted content][1]\n\n[/][0]\n");
+    });
   });
 
   describe('restore', () => {
-    it('can translate basic divclasses', () => {
+    it('can restore basic divclasses', () => {
       const source = "[col-33]\n\nsimple content\n\n[/col-33]";
       const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";
       const output = parser.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"col-33\"><p>contenu simple</p></div>\n");
     });
 
-    it('can translate nested divclasses', () => {
+    it('can restore nested divclasses', () => {
       const source = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
       const redacted = "[][0]\n\n[][1]\n\nimbriqué\n\n[/][1]\n\n[/][0]\n";
       const output = parser.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>imbriqué</p></div></div>\n");
+    });
+
+    it('can restore inline content inside a divclass', () => {
+      const source = "[complex-example]\n\n-   an ordered list\n-   with [other redacted content](http://example.com)\n\n[/complex-example]";
+      const redacted = "[][0]\n\n-   une liste ordonnée\n-   avec [d'autres contenus rédigés][1]\n\n[/][0]\n";
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      expect(output).toEqual("<div class=\"complex-example\"><ul>\n<li>une liste ordonnée</li>\n<li>avec <a href=\"http://example.com\">d'autres contenus rédigés</a></li>\n</ul></div>\n");
     });
   });
 });

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -117,5 +117,48 @@ describe('divclass', () => {
       const output = parser.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"complex-example\"><ul>\n<li>une liste ordonnée</li>\n<li>avec <a href=\"http://example.com\">d'autres contenus rédigés</a></li>\n</ul></div>\n");
     });
+
+    it('can restore content with reordered indexes', () => {
+      const source = "[zero]\n\nzero\n\n[/zero]\n\n[one]\n\none\n\n[/one]";
+      const redacted = "[][1]\n\nun\n\n[/][1]\n\n[][0]\n\nzéro\n\n[/][0]";
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      expect(output).toEqual("<div class=\"one\"><p>un</p></div>\n<div class=\"zero\"><p>zéro</p></div>\n");
+    });
+
+    it('can restore content with nesting changes', () => {
+      const source = "[zero]\n\n[one]\n\n\n\n[/one]\n\n[/zero]"
+
+      const unNestedRedaction = "[][0]\n\n\n\n[/][0]\n\n[][1]\n\n\n\n[/][1]";
+      expect(parser.sourceAndRedactedToHtml(source, unNestedRedaction))
+        .toEqual("<div class=\"zero\"></div>\n<div class=\"one\"></div>\n");
+
+      const invertedRedaction = "[][1]\n\n[][0]\n\n\n\n[/][0]\n\n[/][1]";
+      expect(parser.sourceAndRedactedToHtml(source, invertedRedaction))
+        .toEqual("<div class=\"one\"><div class=\"zero\"></div></div>\n");
+
+      const brokenRedaction = "[][0]\n\n[][1]\n\n\n\n[/][0]\n\n[/][1]"
+      expect(parser.sourceAndRedactedToHtml(source, brokenRedaction))
+        .toEqual("<div class=\"zero\"><p><a href=\"\"></a></p></div>\n<p><a href=\"\">/</a></p>\n");
+    });
+
+    it('can restore content that adds extra content', () => {
+      const source = "[first]\n\nFirst\n\n[/first]\n\n[second]\n\nSecond\n\n[/second]";
+
+      const reusedIndex = "[][0]\n\nPremier\n\n[/][0]\n\n[][1]\n\nDeuxième\n\n[/][1]\n\n[][1]\n\nTroisième\n\n[/][1]"
+      expect(parser.sourceAndRedactedToHtml(source, reusedIndex))
+        .toEqual("<div class=\"first\"><p>Premier</p></div>\n<div class=\"second\"><p>Deuxième</p></div>\n<div class=\"second\"><p>Troisième</p></div>\n");
+
+      // in every case, extra redactions default to empty links
+      const extraIndex = "[][0]\n\nPremier\n\n[/][0]\n\n[][1]\n\nDeuxième\n\n[/][1]\n\n[][2]\n\nTroisième\n\n[/][2]"
+      expect(parser.sourceAndRedactedToHtml(source, extraIndex))
+        .toEqual("<div class=\"first\"><p>Premier</p></div>\n<div class=\"second\"><p>Deuxième</p></div>\n<p><a href=\"\"></a></p>\n<p>Troisième</p>\n<p><a href=\"\">/</a></p>\n");
+    });
+
+    it('can NOT restore content if required whitespace is removed', () => {
+      const source = "[clazz]\n\nCat\n\n[/clazz]";
+      const redacted = "[][0]\nChat\n[/][0]";
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      expect(output).toEqual("<p><a href=\"\"></a>\nChat\n<a href=\"\">/</a></p>\n");
+    });
   });
 });

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -33,6 +33,29 @@ describe('divclass', () => {
       expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>nested</p></div></div>\n");
     });
 
+    it('can nest duplicate divclasses', () => {
+      const input = "[classname]\n\ncontent\n\n[classname]\n\ninner content\n\n[/classname]\n\ncontent\n\n[/classname]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"classname\"><p>content</p><div class=\"classname\"><p>inner content</p></div><p>content</p></div>\n");
+    });
+
+    it('can nest as deeply as you want', () => {
+      const markdownOpen = "[classname]\n\n";
+      const markdownClose = "\n\n[/classname]";
+      const markdownContent = "content";
+      const htmlOpen = "<div class=\"classname\">"
+      const htmlClose = "</div>";
+      const htmlContent = "<p>content</p>";
+
+      let input = markdownContent;
+      let output = htmlContent;
+      for (let _ = 0; _ < 20; _++) {
+        input = `${markdownOpen}${input}${markdownClose}`;
+        output = `${htmlOpen}${output}${htmlClose}`;
+        expect(parser.sourceToHtml(input)).toEqual(output + "\n");
+      }
+    });
+
     it('requires class-specific termination', () => {
       const input = "[example]\n\nsimple content\n\n[/]";
       const output = parser.sourceToHtml(input);

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -56,43 +56,47 @@ describe('divclass', () => {
     it('redacts a basic divclass', () => {
       const input = "[col-33]\n\nsimple content\n\n[/col-33]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n\nsimple content\n\n[/][]\n");
+      expect(output).toEqual("[][0]\n\nsimple content\n\n[/][0]\n");
     });
 
     it('works without content - but only if separated by FOUR newlines', () => {
       const input = "[empty]\n\n\n\n[/empty]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n\n[/][]\n");
+      expect(output).toEqual("[][0]\n\n[/][0]\n");
     });
 
     it('renders a divclass within other content', () => {
       const input = "outside of div\n\n[divname]\n\ninside div\n\n[/divname]\n\nmore outside";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("outside of div\n\n[][0]\n\ninside div\n\n[/][]\n\nmore outside\n");
+      expect(output).toEqual("outside of div\n\n[][0]\n\ninside div\n\n[/][0]\n\nmore outside\n");
     });
 
     it("doesn't care about duplicate classes", () => {
       const input = "[classname]\n\nfirst\n\n[/classname]\n\n[classname]\n\nsecond\n\n[/classname]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n\nfirst\n\n[/][]\n\n[][1]\n\nsecond\n\n[/][]\n");
+      expect(output).toEqual("[][0]\n\nfirst\n\n[/][0]\n\n[][1]\n\nsecond\n\n[/][1]\n");
     });
 
     it('can nest divclasses', () => {
       const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n\n[][1]\n\nnested\n\n[/][]\n\n[/][]\n");
+      expect(output).toEqual("[][0]\n\n[][1]\n\nnested\n\n[/][1]\n\n[/][0]\n");
     });
   });
 
   describe('restore', () => {
     it('can translate basic divclasses', () => {
       const source = "[col-33]\n\nsimple content\n\n[/col-33]";
-      const redacted = "[][0]\n\ncontenu simple\n\n[/][]\n";
-      //let output = parser.sourceAndRedactedToMarkdown(source, redacted);
-      //expect(output).toEqual("[col-33]\n\ncontenu simple\n\n[/col-33]");
+      const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";
       const output = parser.sourceAndRedactedToHtml(source, redacted);
-      //output = parser.sourceToHtml(output);
       expect(output).toEqual("<div class=\"col-33\"><p>contenu simple</p></div>\n");
+    });
+
+    it('can translate nested divclasses', () => {
+      const source = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
+      const redacted = "[][0]\n\n[][1]\n\nimbriqué\n\n[/][1]\n\n[/][0]\n";
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>imbriqué</p></div></div>\n");
     });
   });
 });

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -1,0 +1,98 @@
+const expect = require('expect');
+const parser = require('../../../src/cdoFlavoredParser');
+
+describe('divclass', () => {
+  describe('render', () => {
+    it('renders a basic divclass', () => {
+      const input = "[col-33]\n\nsimple content\n\n[/col-33]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"col-33\"><p>simple content</p></div>\n");
+    });
+
+    it('works without content - but only if separated by FOUR newlines', () => {
+      const input = "[empty]\n\n\n\n[/empty]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"empty\"></div>\n");
+    });
+
+    it('renders a divclass within other content', () => {
+      const input = "outside of div\n\n[divname]\n\ninside div\n\n[/divname]\n\nmore outside";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>outside of div</p>\n<div class=\"divname\"><p>inside div</p></div>\n<p>more outside</p>\n");
+    });
+
+    it("doesn't care about duplicate classes", () => {
+      const input = "[classname]\n\nfirst\n\n[/classname]\n\n[classname]\n\nsecond\n\n[/classname]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"classname\"><p>first</p></div>\n<div class=\"classname\"><p>second</p></div>\n");
+    });
+
+    it('can nest divclasses', () => {
+      const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>nested</p></div></div>\n");
+    });
+
+    it('requires class-specific termination', () => {
+      const input = "[example]\n\nsimple content\n\n[/]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>[example]</p>\n<p>simple content</p>\n<p>[/]</p>\n");
+    });
+
+    it('requires divclasses be in their own paragraphs', () => {
+      const input = "[example]simple content[/example]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>[example]simple content[/example]</p>\n");
+    });
+
+    it('will not unindent', () => {
+      const input = "[example]\n\n    simple content\n\n[/example]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"example\"><pre><code>simple content\n</code></pre></div>\n");
+    });
+  });
+
+  describe('redact', () => {
+    it('redacts a basic divclass', () => {
+      const input = "[col-33]\n\nsimple content\n\n[/col-33]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n\nsimple content\n\n[/][]\n");
+    });
+
+    it('works without content - but only if separated by FOUR newlines', () => {
+      const input = "[empty]\n\n\n\n[/empty]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n\n[/][]\n");
+    });
+
+    it('renders a divclass within other content', () => {
+      const input = "outside of div\n\n[divname]\n\ninside div\n\n[/divname]\n\nmore outside";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("outside of div\n\n[][0]\n\ninside div\n\n[/][]\n\nmore outside\n");
+    });
+
+    it("doesn't care about duplicate classes", () => {
+      const input = "[classname]\n\nfirst\n\n[/classname]\n\n[classname]\n\nsecond\n\n[/classname]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n\nfirst\n\n[/][]\n\n[][1]\n\nsecond\n\n[/][]\n");
+    });
+
+    it('can nest divclasses', () => {
+      const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n\n[][1]\n\nnested\n\n[/][]\n\n[/][]\n");
+    });
+  });
+
+  describe('restore', () => {
+    it('can translate basic divclasses', () => {
+      const source = "[col-33]\n\nsimple content\n\n[/col-33]";
+      const redacted = "[][0]\n\ncontenu simple\n\n[/][]\n";
+      //let output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      //expect(output).toEqual("[col-33]\n\ncontenu simple\n\n[/col-33]");
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      //output = parser.sourceToHtml(output);
+      expect(output).toEqual("<div class=\"col-33\"><p>contenu simple</p></div>\n");
+    });
+  });
+});


### PR DESCRIPTION
This PR extends quite a bit on https://github.com/code-dot-org/cdo-flavored-markdown/pull/5 to add redact/restore/render support for block-style syntaxes as well as inline-style syntaxes, and then uses that support to add a new `divclass` syntax