### PR TITLE
Update restoration process to always get to HTML by way of Markdown

### DIFF
--- a/src/cdoFlavoredParser.js
+++ b/src/cdoFlavoredParser.js
@@ -3,6 +3,7 @@ const parse = require('remark-parse');
 const stringify = require('remark-stringify');
 const unified = require('unified');
 
+// process plugins
 const renderRedactions = require('./plugins/renderRedactions');
 const restoreRedactions = require('./plugins/restoreRedactions');
 const restorationRegistration = require('./plugins/restorationRegistration');

--- a/src/cdoFlavoredParser.js
+++ b/src/cdoFlavoredParser.js
@@ -7,12 +7,20 @@ const renderRedactions = require('./plugins/renderRedactions');
 const restoreRedactions = require('./plugins/restoreRedactions');
 const restorationRegistration = require('./plugins/restorationRegistration');
 
+// compiler plugins
+const rawtext = require('./plugins/rawtext');
+
+// parser plugins
 const divclass = require('./plugins/divclass');
 const redactedLink = require('./plugins/redactedLink');
 const tiplink = require('./plugins/tiplink');
 
 module.exports = class CdoFlavoredParser {
   static getPlugins = function() {
+    return this.getParserPlugins().concat(this.getCompilerPlugins());
+  }
+
+  static getParserPlugins = function() {
     return [
       restorationRegistration,
       divclass,
@@ -21,16 +29,29 @@ module.exports = class CdoFlavoredParser {
     ];
   };
 
+  static getCompilerPlugins = function() {
+    return [
+      rawtext,
+    ]
+  }
+
   static getParser = function() {
-    return unified().use(parse).use(this.getPlugins());
+    return unified()
+      .use(parse)
+      .use(this.getParserPlugins());
   };
 
   static sourceToHtml = function(source) {
-    return this.getParser().use(html).processSync(source).contents;
+    return this.getParser()
+      .use(html)
+      .processSync(source)
+      .contents;
   };
 
   static sourceToRedactedMdast = function(source) {
-    return this.getParser().use({ settings: { redact: true } }).parse(source);
+    return this.getParser()
+      .use({ settings: { redact: true } })
+      .parse(source);
   };
 
   static sourceToRedacted = function(source) {
@@ -50,13 +71,16 @@ module.exports = class CdoFlavoredParser {
     return redactedTree;
   };
 
-  static sourceAndRedactedToHtml = function(source, redacted) {
-    const mergedMdast = this.sourceAndRedactedToMergedMdast(source, redacted);
-    return this.getParser().use(html).stringify(mergedMdast);
-  };
-
   static sourceAndRedactedToMarkdown = function(source, redacted) {
     const mergedMdast = this.sourceAndRedactedToMergedMdast(source, redacted);
-    return this.getParser().use(stringify).stringify(mergedMdast);
+    return this.getParser()
+      .use(stringify)
+      .use(this.getCompilerPlugins())
+      .stringify(mergedMdast);
+  };
+
+  static sourceAndRedactedToHtml = function(source, redacted) {
+    const restoredMarkdown = this.sourceAndRedactedToMarkdown(source, redacted);
+    return this.sourceToHtml(restoredMarkdown);
   };
 };

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -77,11 +77,17 @@ module.exports = function divclass() {
     const open = add({
       type: 'paragraph',
       children: [{
-        type: 'rawtext',
+        type: 'rawtext', // use rawtext rather than text to avoid escaping the `[`
         value: `[${nodes.open.className}]`
       }]
     });
 
+    // Restored divclasses must always have a child; otherwise, an empty
+    // restored divclass would look like `[classname]\n\n[/classname]` which is
+    // not recognized by the parser.
+    // See the test "divclass render works without content - but only if separated by FOUR newlines".
+    // If the parser can be taught to reliably recognize a divclass without that
+    // requirement, this step can be removed
     if (!children.length) {
       children = [{
         type: 'text',

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -74,15 +74,32 @@ module.exports = function divclass() {
   const restorationMethods = Parser.prototype.restorationMethods;
 
   restorationMethods.divclass = function (add, nodes, content, children) {
-    return add({
-      type: 'div',
-      children,
-      data: {
-        hProperties: {
-          className: nodes.open.className
-        },
-      }
+    const open = add({
+      type: 'paragraph',
+      children: [{
+        type: 'rawtext',
+        value: `[${nodes.open.className}]`
+      }]
     });
+
+    if (!children.length) {
+      children = [{
+        type: 'text',
+        value: ''
+      }];
+    }
+    const childNodes = children.map(child => add(child))
+
+    const close = add({
+      type: 'paragraph',
+      children: [{
+        type: 'rawtext',
+        value: `[/${nodes.open.className}]`
+      }]
+    });
+
+
+    return [open, ...childNodes, close];
   }
 
   redact = Parser.prototype.options.redact;

--- a/src/plugins/rawtext.js
+++ b/src/plugins/rawtext.js
@@ -1,3 +1,10 @@
+/**
+ * Stringify text without escaping special characters; useful for rendering
+ * custom syntaxes which include control characters back to markdown.
+ *
+ * @see https://github.com/remarkjs/remark/blob/remark-stringify%405.0.0/packages/remark-stringify/lib/visitors/text.js
+ * @see divclass
+ */
 module.exports = function rawtext() {
   if (this.Compiler) {
     const Compiler = this.Compiler;

--- a/src/plugins/rawtext.js
+++ b/src/plugins/rawtext.js
@@ -1,0 +1,10 @@
+module.exports = function rawtext() {
+  if (this.Compiler) {
+    const Compiler = this.Compiler;
+    const visitors = Compiler.prototype.visitors;
+
+    visitors.rawtext = function (node) {
+      return this.encode(node.value, node);
+    }
+  }
+}

--- a/src/plugins/restorationRegistration.js
+++ b/src/plugins/restorationRegistration.js
@@ -3,7 +3,7 @@
  *
  * This extension simply adds the `Parser.prototype.restorationMethods`
  * property, which plugins that implement redaction can use to register the
- * methods required to restore the redacted content.
+ * methods required to restore the redacted content back to markdown.
  *
  * Plugins that implement redaction should implement it by generating a
  * [MDAST Node](https://github.com/syntax-tree/mdast#ast) that implements the
@@ -45,13 +45,16 @@
  * - `node` - the MDAST Node returned by redaction
  * - `content` - the modified content, if it exists
  *
+ * And should act as a tokenizer that can render a version of the original
+ * markdown with the redacted content in-place and the rendered content replaced
+ * by the new content
+ *
  * For example:
  *
  *     Parser.prototype.restorationMethods.mention = function (add, node, content) {
  *       return add({
- *         type: 'link',
- *         url: node.url,
- *         children: [{type: 'text', value: content}]
+ *         type: 'text',
+ *         value: `@${content}`
  *       });
  *     }
  *

--- a/src/plugins/tiplink.js
+++ b/src/plugins/tiplink.js
@@ -13,7 +13,10 @@ module.exports = function mention() {
     const restorationMethods = Parser.prototype.restorationMethods;
 
     restorationMethods.tiplink = function (add, node) {
-      return createTiplink(add, node.tipType, node.tipLink);
+      return add({
+        type: 'text',
+        value: `${node.tipType}!!! ${node.tipLink}`
+      });
     }
 
     redact = Parser.prototype.options.redact;

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -120,6 +120,13 @@ describe('divclass', () => {
   });
 
   describe('restore', () => {
+    it('can restore basic divclasses back to markdown', () => {
+      const source = "[col-33]\n\nsimple content\n\n[/col-33]";
+      const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";
+      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      expect(output).toEqual("[col-33]\n\ncontenu simple\n\n[/col-33]\n");
+    });
+
     it('can restore basic divclasses', () => {
       const source = "[col-33]\n\nsimple content\n\n[/col-33]";
       const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -10,9 +10,10 @@ describe('divclass', () => {
     });
 
     it('works without content - but only if separated by FOUR newlines', () => {
-      const input = "[empty]\n\n\n\n[/empty]";
-      const output = parser.sourceToHtml(input);
-      expect(output).toEqual("<div class=\"empty\"></div>\n");
+      const validInput = "[empty]\n\n\n\n[/empty]";
+      expect(parser.sourceToHtml(validInput)).toEqual("<div class=\"empty\"></div>\n");
+      const invalidInput = "[empty]\n\n[/empty]";
+      expect(parser.sourceToHtml(invalidInput)).toEqual("<p>[empty]</p>\n<p>[/empty]</p>\n");
     });
 
     it('renders a divclass within other content', () => {

--- a/test/unit/plugins/tiplink.test.js
+++ b/test/unit/plugins/tiplink.test.js
@@ -64,6 +64,13 @@ describe('tiplink', () => {
   });
 
   describe('restore', () => {
+    it('can restore tiplinks back to markdown', () => {
+      const source = "This is some text with an inline labeled tip: " + labeledTipMarkdown;
+      const redacted = "Ceci est un texte avec un [][0] inline labeled tip";
+      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      expect(output).toEqual("Ceci est un texte avec un tip!!! tip-0 inline labeled tip\n");
+    });
+
     it('can translate tiplinks', () => {
       const source = "This is some text with an inline labeled tip: " + labeledTipMarkdown;
       const redacted = "Ceci est un texte avec un [][0] inline labeled tip";


### PR DESCRIPTION
Rather than just always rendering straight to HTML.

By adjusting the restoration expectations to just output markdown, we can get both restored markdown and restored HTML