### PR TITLE
add actual tiplink locator method

### DIFF
--- a/src/plugins/tiplink.js
+++ b/src/plugins/tiplink.js
@@ -1,6 +1,7 @@
 let redact;
 
 const TIPLINK_RE = /^([\w-]+)!!! ?([\w-]+)?/
+const TIPLINK_LOCATOR_RE = /[\w-]+!!!/;
 
 /**
  * @requires restorationRegistration
@@ -101,5 +102,8 @@ function tokenizeTiplink(eat, value, silent) {
 }
 
 function locateTiplink(value, fromIndex) {
-  return fromIndex;
+  const match = TIPLINK_LOCATOR_RE.exec(value);
+  if (match && match.index >= fromIndex) {
+    return match.index;
+  }
 }


### PR DESCRIPTION
as prescribed in https://github.com/remarkjs/remark/tree/master/packages/remark-parse#tokenizerlocatorvalue-fromindex

The basic placeholder I had before, although capable of returning technically correct results, was slowing down my integration tests by a factor of six!!