### PR TITLE
add support for Curriculum Builder vocablink syntax

### DIFF
--- a/src/cdoFlavoredParser.js
+++ b/src/cdoFlavoredParser.js
@@ -16,6 +16,7 @@ const divclass = require('./plugins/divclass');
 const redactedLink = require('./plugins/redactedLink');
 const resourcelink = require('./plugins/resourcelink');
 const tiplink = require('./plugins/tiplink');
+const vocablink = require('./plugins/vocablink');
 
 module.exports = class CdoFlavoredParser {
   static getPlugins = function() {
@@ -29,6 +30,7 @@ module.exports = class CdoFlavoredParser {
       redactedLink,
       resourcelink,
       tiplink,
+      vocablink,
     ];
   };
 

--- a/src/plugins/vocablink.js
+++ b/src/plugins/vocablink.js
@@ -1,6 +1,6 @@
 let redact;
 
-const VOCABLINK_RE = /^\[v ([^\]]+)\]/;
+const VOCABLINK_RE = /^\[v ([^\]]+)\](?:\[([^\]]+)\])?/;
 const VOCABLINK = 'vocablink';
 
 /**
@@ -19,10 +19,14 @@ module.exports = function vocablink() {
     redact = Parser.prototype.options.redact;
     Parser.prototype.inlineTokenizers[VOCABLINK] = tokenizeVocablink;
 
-    Parser.prototype.restorationMethods[VOCABLINK] = function (add, node) {
+    Parser.prototype.restorationMethods[VOCABLINK] = function (add, node, content) {
+      let value = `[v ${node.vocabword}]`;
+      if (content) {
+        value += `[${content}]`
+      }
       return add({
         type: 'rawtext',
-        value: `[v ${node.slug}]`
+        value 
       });
     }
 
@@ -44,11 +48,16 @@ function tokenizeVocablink(eat, value, silent) {
       return true;
     }
 
-    const slug = match[1];
+    const vocabword = match[1];
+    const override = match[2];
     return eat(match[0])({
       type: 'redaction',
       redactionType: VOCABLINK,
-      slug
+      vocabword,
+      children: [{
+        type: 'text',
+        value: override || vocabword
+      }]
     });
   }
 }

--- a/src/plugins/vocablink.js
+++ b/src/plugins/vocablink.js
@@ -42,22 +42,32 @@ tokenizeVocablink.locator = locateVocablink;
 function tokenizeVocablink(eat, value, silent) {
   const match = VOCABLINK_RE.exec(value);
 
-  // Vocab links are ONLY supported in redaction mode
-  if (match && redact) {
+  if (match) {
     if (silent) {
       return true;
     }
 
+    const add = eat(match[0]);
     const vocabword = match[1];
     const override = match[2];
-    return eat(match[0])({
-      type: 'redaction',
-      redactionType: VOCABLINK,
-      vocabword,
-      children: [{
-        type: 'text',
-        value: override || vocabword
-      }]
+    if (redact) {
+      return add({
+        type: 'redaction',
+        redactionType: VOCABLINK,
+        vocabword,
+        children: [{
+          type: 'text',
+          value: override || vocabword
+        }]
+      });
+    }
+
+    // In non-redaction mode, eat the vocab link so it is not treated as a
+    // different bit of syntax (such as linkReference) but simply output it back
+    // to the raw string
+    return add({
+      type: 'rawtext',
+      value: match[0]
     });
   }
 }

--- a/src/plugins/vocablink.js
+++ b/src/plugins/vocablink.js
@@ -1,0 +1,58 @@
+let redact;
+
+const VOCABLINK_RE = /^\[v ([^\]]+)\]/;
+const VOCABLINK = 'vocablink';
+
+/**
+ * Plugin that adds support for Curriculum Builder's vocablinks.
+ *
+ * Note that vocab links are ONLY supported in redaction mode; rendering them
+ * out requires CurriculumBuilder database access, so they can only be rendered
+ * by Curriculum Builder itself.
+ *
+ * see https://github.com/mrjoshida/curriculumbuilder/blob/bf74aa5/curriculumBuilder/vocablinks.py
+ * @requires restorationRegistration
+ */
+module.exports = function vocablink() {
+  if (this.Parser) {
+    const Parser = this.Parser;
+    redact = Parser.prototype.options.redact;
+    Parser.prototype.inlineTokenizers[VOCABLINK] = tokenizeVocablink;
+
+    Parser.prototype.restorationMethods[VOCABLINK] = function (add, node) {
+      return add({
+        type: 'rawtext',
+        value: `[v ${node.slug}]`
+      });
+    }
+
+    // Run it just before `html`
+    const methods = Parser.prototype.inlineMethods;
+    methods.splice(methods.indexOf('html'), 0, VOCABLINK);
+  }
+}
+
+tokenizeVocablink.notInLink = true;
+tokenizeVocablink.locator = locateVocablink;
+
+function tokenizeVocablink(eat, value, silent) {
+  const match = VOCABLINK_RE.exec(value);
+
+  // Vocab links are ONLY supported in redaction mode
+  if (match && redact) {
+    if (silent) {
+      return true;
+    }
+
+    const slug = match[1];
+    return eat(match[0])({
+      type: 'redaction',
+      redactionType: VOCABLINK,
+      slug
+    });
+  }
+}
+
+function locateVocablink(value, fromIndex) {
+  return value.indexOf("[v ", fromIndex);
+}

--- a/test/unit/plugins/vocablink.test.js
+++ b/test/unit/plugins/vocablink.test.js
@@ -1,12 +1,40 @@
 const expect = require('expect');
 const parser = require('../../../src/cdoFlavoredParser');
+const mapMdast = require('../../utils').mapMdast;
 
 describe('vocablink', () => {
+  describe('parse', () => {
+    it('can distinguish between vocablinks with word overrides and linkReferences', () => {
+      // the only difference between these two bits of the syntax is the "v "
+      const vocablink = parser.getParser().parse("[v some-word][override]");
+      const linkReference = parser.getParser().parse("[some-word][override]");
+      expect(mapMdast(vocablink)).toEqual({
+        children: [{ children: [{ type: 'rawtext' }], type: 'paragraph' }],
+        type: 'root',
+      });
+      expect(mapMdast(linkReference)).toEqual({
+        children: [
+          {
+            children: [{ children: [{ type: 'text' }], type: 'linkReference' }],
+            type: 'paragraph',
+          },
+        ],
+        type: 'root',
+      });
+    });
+  });
+
   describe('render', () => {
-    it('cannot render vocablinks to html', () => {
+    it('can only render vocablinks back out to plain text', () => {
       const input = "[v some-word]";
       const output = parser.sourceToHtml(input);
       expect(output).toEqual("<p>[v some-word]</p>\n");
+    });
+
+    it('can only render vocablinks with word overrides back out to plain text', () => {
+      const input = "[v some-word][override]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>[v some-word][override]</p>\n");
     });
   });
 

--- a/test/unit/plugins/vocablink.test.js
+++ b/test/unit/plugins/vocablink.test.js
@@ -4,35 +4,39 @@ const parser = require('../../../src/cdoFlavoredParser');
 describe('vocablink', () => {
   describe('render', () => {
     it('cannot render vocablinks to html', () => {
-      const input = "[v some-slug]";
+      const input = "[v some-word]";
       const output = parser.sourceToHtml(input);
-      expect(output).toEqual("<p>[v some-slug]</p>\n");
+      expect(output).toEqual("<p>[v some-word]</p>\n");
     });
   });
 
   describe('redact', () => {
     it('redacts vocablinks', () => {
-      const input = "[v some-slug]";
+      const input = "[v some-word]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n");
+      expect(output).toEqual("[some-word][0]\n");
+    });
+
+    it('redacts vocablinks with word overrides', () => {
+      const input = "[v some-word][un-mot]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[un-mot][0]\n");
     });
   });
 
   describe('restore', () => {
     it('can restore vocablinks back to markdown', () => {
-      const source = "[v some-slug]";
-      const redacted = "[][0]"
+      const source = "[v some-word]";
+      const redacted = "[un-mot][0]"
       const output = parser.sourceAndRedactedToMarkdown(source, redacted);
-      expect(output).toEqual("[v some-slug]\n");
+      expect(output).toEqual("[v some-word][un-mot]\n");
     });
 
-    it('can only restore vocablinks to HTML by rendering the raw syntax', () => {
-      // see the comment on the plugin definition for more context as to why
-      // this is true
-      const source = "[v some-slug]";
-      const redacted = "[][0]"
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
-      expect(output).toEqual("<p>[v some-slug]</p>\n");
+    it('can restore vocablinks with word overrides back to markdown', () => {
+      const source = "[v some-word][source-override]";
+      const redacted = "[redaction-override][0]"
+      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      expect(output).toEqual("[v some-word][redaction-override]\n");
     });
   });
 });

--- a/test/unit/plugins/vocablink.test.js
+++ b/test/unit/plugins/vocablink.test.js
@@ -1,0 +1,38 @@
+const expect = require('expect');
+const parser = require('../../../src/cdoFlavoredParser');
+
+describe('vocablink', () => {
+  describe('render', () => {
+    it('cannot render vocablinks to html', () => {
+      const input = "[v some-slug]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>[v some-slug]</p>\n");
+    });
+  });
+
+  describe('redact', () => {
+    it('redacts vocablinks', () => {
+      const input = "[v some-slug]";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("[][0]\n");
+    });
+  });
+
+  describe('restore', () => {
+    it('can restore vocablinks back to markdown', () => {
+      const source = "[v some-slug]";
+      const redacted = "[][0]"
+      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      expect(output).toEqual("[v some-slug]\n");
+    });
+
+    it('can only restore vocablinks to HTML by rendering the raw syntax', () => {
+      // see the comment on the plugin definition for more context as to why
+      // this is true
+      const source = "[v some-slug]";
+      const redacted = "[][0]"
+      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      expect(output).toEqual("<p>[v some-slug]</p>\n");
+    });
+  });
+});


### PR DESCRIPTION
Very similar to the resourcelinks as defined in https://github.com/code-dot-org/cdo-flavored-markdown/pull/9