### PR TITLE
display but do not use resourcelink slug in redaction

### DIFF
--- a/src/plugins/resourcelink.js
+++ b/src/plugins/resourcelink.js
@@ -48,7 +48,11 @@ function tokenizeResourcelink(eat, value, silent) {
     return eat(match[0])({
       type: 'redaction',
       redactionType: RESOURCELINK,
-      slug
+      slug,
+      children: [{
+        type: 'text',
+        value: slug
+      }]
     });
   }
 }

--- a/test/unit/plugins/resourcelink.test.js
+++ b/test/unit/plugins/resourcelink.test.js
@@ -14,14 +14,14 @@ describe('resourcelink', () => {
     it('redacts resourcelinks', () => {
       const input = "[r some-slug]";
       const output = parser.sourceToRedacted(input);
-      expect(output).toEqual("[][0]\n");
+      expect(output).toEqual("[some-slug][0]\n");
     });
   });
 
   describe('restore', () => {
     it('can restore resourcelinks back to markdown', () => {
       const source = "[r some-slug]";
-      const redacted = "[][0]"
+      const redacted = "[any-text][0]"
       const output = parser.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("[r some-slug]\n");
     });
@@ -30,7 +30,7 @@ describe('resourcelink', () => {
       // see the comment on the plugin definition for more context as to why
       // this is true
       const source = "[r some-slug]";
-      const redacted = "[][0]"
+      const redacted = "[any-text][0]"
       const output = parser.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>[r some-slug]</p>\n");
     });


### PR DESCRIPTION
Resourcelinks in curriculumbuilder are used extensively like so:

```
- Watch the [r my-robotic-friends].
- Read [r my-robotic-friends-packet].
- Print out one [r symbol-key] per group. This is "code" to be used.
- [r paper-trapezoid-template] are provided if your class is not going to use cups.
- Print out one set of [r stacking-cups-ideas] per group.
- Make sure each student has a [r think-spot-journal].
```

In the original redaction scheme, these would get redacted like:

```
-   Watch the [][0].
-   Read [][1].
-   Print out one [][2] per group. This is "code" to be used.
-   [][3] are provided if your class is not going to use cups.
-   Print out one set of [][4] per group.
-   Make sure each student has a [][5].
```

But that results in content that's not super readable for the translator. Instead, we now include the original slug in the redaction like so:

```
-   Watch the [my-robotic-friends][0].
-   Read [my-robotic-friends-packet][1].
-   Print out one [symbol-key][2] per group. This is "code" to be used.
-   [paper-trapezoid-template][3] are provided if your class is not going to use cups.
-   Print out one set of [stacking-cups-ideas][4] per group.
-   Make sure each student has a [think-spot-journal][5].
```

But do not actually use it in the restoration process.
