### PR TITLE
Update divclass implementation to support whitespace

### DIFF
--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -62,7 +62,7 @@
  * [/][0]
  */
 
-const DIVCLASS_OPEN_RE = /^\[([\w-]+)\]\n\n/;
+const DIVCLASS_OPEN_RE = /^\[([\w-]+)\] *\n *\n/;
 
 let redact;
 
@@ -129,8 +129,8 @@ function tokenizeDivclass(eat, value, silent) {
   const startIndex = startMatch[0].length;
   const className = startMatch[1];
 
-  const MATCHING_DIVCLASS_OPEN_RE = new RegExp(`\\[${className}\\]\\n\\n`, 'g');
-  const MATCHING_DIVCLASS_CLOSE_RE = new RegExp(`\\n\\n\\[\\/${className}\\]`, 'g');
+  const MATCHING_DIVCLASS_OPEN_RE = new RegExp(`\\[${className}\\] *\\n *\\n`, 'g');
+  const MATCHING_DIVCLASS_CLOSE_RE = new RegExp(`\\n *\\n *\\[\\/${className}\\]`, 'g');
 
   MATCHING_DIVCLASS_CLOSE_RE.lastIndex = startIndex;
 

--- a/src/plugins/divclass.js
+++ b/src/plugins/divclass.js
@@ -129,31 +129,40 @@ function tokenizeDivclass(eat, value, silent) {
   const startIndex = startMatch[0].length;
   const className = startMatch[1];
 
-  const divclassClose = `\n\n[/${className}]`;
+  const MATCHING_DIVCLASS_OPEN_RE = new RegExp(`\\[${className}\\]\\n\\n`, 'g');
+  const MATCHING_DIVCLASS_CLOSE_RE = new RegExp(`\\n\\n\\[\\/${className}\\]`, 'g');
 
-  // the first instance of a matching close block in the rest of the value
-  // string. Note that because of nesting, this may not necessarily be the
-  // actual matching close block we want.
-  let nextMatchingClose = value.indexOf(divclassClose, startIndex);
+  MATCHING_DIVCLASS_CLOSE_RE.lastIndex = startIndex;
 
-  // to find out, we look at everything in between the opening block and the
-  // selected closing block. If there are an equal number of opens and closes
-  // within that subvalue, we're good; otherwise, select the next matching close
-  // and try again
-  let subvalue = value.slice(startIndex, nextMatchingClose);
-  while (subvalue.split(divclassOpen).length !== subvalue.split(divclassClose).length) {
-    nextMatchingClose = value.indexOf(divclassClose, nextMatchingClose + 1);
-    subvalue = value.slice(startIndex, nextMatchingClose);
-  }
+  let nextMatchingClose;
+  let subvalue;
+  let endIndex;
 
-  if (nextMatchingClose === -1) {
-    return;
-  }
+  do {
+    // find the first instance of a matching close block in the rest of the
+    // value string. Note that because of nesting, this may not necessarily be
+    // the actual matching close block we want.
+    nextMatchingClose = MATCHING_DIVCLASS_CLOSE_RE.exec(value);
+
+    // if at any point we "run out" of matches before finding a valid one, then
+    // fail fast
+    if (MATCHING_DIVCLASS_CLOSE_RE.lastIndex === 0) {
+      return
+    }
+    endIndex = MATCHING_DIVCLASS_CLOSE_RE.lastIndex - nextMatchingClose[0].length;
+    subvalue = value.slice(startIndex, endIndex);
+
+    // to find out, we look at everything in between the opening block and the
+    // selected closing block. If there are an equal number of opens and closes
+    // within that subvalue, we're good; otherwise, select the next matching close
+    // and try again
+  } while (subvalue.split(MATCHING_DIVCLASS_OPEN_RE).length !== subvalue.split(MATCHING_DIVCLASS_CLOSE_RE).length)
 
   if (silent) {
     return true;
   }
 
+  const divclassClose = nextMatchingClose[0];
   const contents = this.tokenizeBlock(subvalue, eat.now());
 
   if (redact) {

--- a/test/unit/plugins/divclass.test.js
+++ b/test/unit/plugins/divclass.test.js
@@ -9,6 +9,12 @@ describe('divclass', () => {
       expect(output).toEqual("<div class=\"col-33\"><p>simple content</p></div>\n");
     });
 
+    it('renders a basic divclass even with a bunch of extra whitespace', () => {
+      const input = "[col-33]   \n \nsimple content\n  \n     [/col-33]";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<div class=\"col-33\"><p>simple content</p></div>\n");
+    });
+
     it('works without content - but only if separated by FOUR newlines', () => {
       const validInput = "[empty]\n\n\n\n[/empty]";
       expect(parser.sourceToHtml(validInput)).toEqual("<div class=\"empty\"></div>\n");


### PR DESCRIPTION
As currently implemented, the open and close blocks of divclasses are pretty strict about being separated by just newlines with no whitespace; strictly `[className]\n\ncontent\n\n[/className]`

Unfortunately, in markdown extra whitespace should generally be ignored, so our divclass tags should similarly not care about extra whitespace; something like `[className   \n  \ncontent\n \n[/className]` should work just fine.

That means that even if we know the classname of the opening bracket, we can't use strict string matching to find the closing bracket, so the whole implementation has to be updated to use regexes instead of `indexOf`