### PR TITLE
Standardize image redaction

### DIFF
--- a/src/plugins/parser/redactedLink.js
+++ b/src/plugins/parser/redactedLink.js
@@ -72,6 +72,12 @@ module.exports = function redactedLink() {
 function tokenizeRedactedLink(eat, value, silent) {
   const link = tokenizeLink.call(this, eat, value, silent);
   if (link) {
+    if (link.type === 'image') {
+      link.children = [{
+        type: 'text',
+        value: link.alt
+      }]
+    }
     link.redactionType = 'redacted' + link.type;
     link.type = 'redaction';
   }

--- a/src/plugins/process/renderRedactions.js
+++ b/src/plugins/process/renderRedactions.js
@@ -44,8 +44,6 @@ module.exports = function renderRedactions() {
       var exit = self.enterLink();
       if (node.children) {
         value = self.all(node).join('');
-      } else if (node.alt) {
-        value = self.encode(self.escape(node.alt || '', node))
       }
       exit();
 


### PR DESCRIPTION
An artifact of early iterations on redaction, images would be redacted
by just changing their type and leaving all their other information
(namely, the alt text that we actually care about) in place. Then, the
redaction rendering step had logic to render both image-style redactions
and link-style redactions.

Since then, all other redactions have become standardized to always
operate the way links do, but the images were still doing their own
thing. Now, _all_ redactions use exclusively children rather than alt.