### PR TITLE
Update build process to treat executables as primary target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 /coverage
 
 # Build files
-/build/*
+/demo/build
+/dist
 
 # OS X
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ notifications:
   email: false
 
 before_deploy:
-  - npm run build
+  - npm run build:demo
 
 deploy:
-  local_dir: build
+  local_dir: demo/build
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require("path");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: "./demo/demo.jsx",
+  output: {
+    path: path.resolve(__dirname, "build"),
+    filename: "bundle.js",
+  },
+  module: {
+    rules: [{
+      test: /\.jsx?$/,
+      loader: "babel-loader",
+    }, {
+      test: /\.md$/,
+      loader: 'raw-loader',
+    }]
+  },
+  plugins: [
+    new HtmlWebpackPlugin()
+  ],
+  resolve: {
+    extensions: [".js", ".jsx"],
+  },
+  stats: {
+    colors: true
+  },
+  devtool: 'source-map',
+  devServer: { inline: true }
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "cdo-flavored-markdown",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "bin": {
+    "redact": "dist/bin/redact.js",
+    "render": "dist/bin/render.js",
+    "restore": "dist/bin/restore.js"
+  },
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --progress --colors --mode=development",

--- a/package.json
+++ b/package.json
@@ -4,19 +4,23 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --progress --colors",
-    "lint": "eslint --ext .js src/ test",
+    "build": "webpack -p",
+    "build:dev": "webpack --progress --colors --mode=development",
+    "build:demo": "webpack --config ./demo/webpack.config.js",
+    "lint": "eslint --ext .js src/ test/",
     "test": "npm run lint && jest",
     "test:unit": "jest test/unit",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:integration": "jest test/integration",
-    "test:integration:watch": "npm run test:integration -- --watch",
-    "watch": "webpack-dev-server --progress --colors"
+    "test:integration:watch": "npm run test:integration -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:code-dot-org/cdo-flavored-markdown.git"
   },
   "author": "Code.org <dev@code.org> (http://code.org)",
   "license": "ISC",
   "devDependencies": {
-    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.2.2",
@@ -26,19 +30,18 @@
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.17.0",
     "eslint-plugin-babel": "^4.1.2",
-    "file-loader": "^1.1.6",
-    "html-webpack-plugin": "^2.30.1",
+    "html-webpack-plugin": "^3.2.0",
     "jest": "^22.2.2",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
+    "webpack": "^4.8.1",
+    "webpack-cli": "^2.1.3"
+  },
+  "dependencies": {
     "minimist": "^1.2.0",
-    "pretty-format": "^22.1.0",
-    "raw-loader": "^0.5.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
     "remark-html": "^7.0.0",
     "remark-parse": "^5.0.0",
     "remark-stringify": "^5.0.0",
-    "unified": "^7.0.0",
-    "webpack": "^3.8.1",
-    "webpack-dev-server": "^2.9.5"
+    "unified": "^7.0.0"
   }
 }

--- a/src/bin/redact.js
+++ b/src/bin/redact.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env babel-node
-
 const parser = require('../cdoFlavoredParser');
 const parseArgs = require('minimist')
 const fs = require('fs');

--- a/src/bin/render.js
+++ b/src/bin/render.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env babel-node
-
 const parser = require('../cdoFlavoredParser');
 const parseArgs = require('minimist')
 const fs = require('fs');

--- a/src/bin/restore.js
+++ b/src/bin/restore.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env babel-node
-
 const parser = require('../cdoFlavoredParser');
 const parseArgs = require('minimist')
 const fs = require('fs');

--- a/src/bin/view.js
+++ b/src/bin/view.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env babel-node
-
 const parseArgs = require('minimist')
 const fs = require('fs');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,30 +1,23 @@
-const path = require("path");
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
-  entry: "./demo/demo.jsx",
-  output: {
-    path: path.resolve(__dirname, "build"),
-    filename: "bundle.js",
+  entry: {
+    "bin/redact": "./src/bin/redact.js",
+    "bin/render": "./src/bin/render.js",
+    "bin/restore": "./src/bin/restore.js"
   },
+  target: 'node',
   module: {
     rules: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader: "babel-loader",
-    }, {
-      test: /\.md$/,
-      loader: 'raw-loader',
     }]
   },
   plugins: [
-    new HtmlWebpackPlugin()
-  ],
-  resolve: {
-    extensions: [".js", ".jsx"],
-  },
-  stats: {
-    colors: true
-  },
-  devtool: 'source-map',
-  devServer: { inline: true }
+    new webpack.BannerPlugin({
+      banner: '#!/usr/bin/env node',
+      raw: true
+    })
+  ]
 };
+


### PR DESCRIPTION
I'm still not 100% sure how we're going to want to expose this project in the long-term, but at least for now I know I'm going to want easy access to the executable `redact` and `restore` operations, so for now we update the build process to have those be the primary (and sole) output, and configure package.json to expose them when installed with NPM.

To that end, shuffle the build process for the https://code-dot-org.github.io/cdo-flavored-markdown/ demo page into its own subdirectory 

Depends on https://github.com/code-dot-org/cdo-flavored-markdown/pull/25