### PR TITLE
Fix linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   "parserOptions": {
     "sourceType": "module",
     "ecmaFeatures": {
-      "jsx": true,
       "modules": true,
       "ecmaVersion": 6,
       "experimentalObjectRestSpread": true
@@ -13,12 +12,10 @@ module.exports = {
   },
 
   "plugins": [
-    "react",
     "babel",
   ],
   "extends": [
     "eslint:recommended",
-    "plugin:react/recommended"
   ],
 
   "env": {


### PR DESCRIPTION
Eslint React plugins were removed in
https://github.com/code-dot-org/cdo-flavored-markdown/pull/25, but I
forgot to also stop _using_ them